### PR TITLE
Tentative fix for STOR-718

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>StoRM Backend server</name>
   <groupId>org.italiangrid.storm</groupId>
   <artifactId>storm-backend-server</artifactId>
-  <version>1.11.7-SNAPSHOT</version>
+  <version>1.11.7</version>
 
   <properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>StoRM Backend server</name>
   <groupId>org.italiangrid.storm</groupId>
   <artifactId>storm-backend-server</artifactId>
-  <version>1.11.6</version>
+  <version>1.11.7-SNAPSHOT</version>
 
   <properties>
 

--- a/src/main/java/it/grid/storm/catalogs/surl/SURLStatusDAO.java
+++ b/src/main/java/it/grid/storm/catalogs/surl/SURLStatusDAO.java
@@ -47,8 +47,8 @@ public class SURLStatusDAO {
         + "JOIN (request_Get rg, request_queue rq) "
         + "ON sg.request_GetID=rg.ID AND rg.request_queueID=rq.ID "
         + "SET sg.statusCode=20, rq.status=20, sg.explanation=? "
-        + "WHERE (sg.statusCode=22 OR sg.statusCode=17) "
-        + "AND rg.sourceSURL = ? ";
+        + "WHERE rg.sourceSURL = ? and rg.sourceSURL_uniqueID = ? "
+        + "AND (sg.statusCode=22 OR sg.statusCode=17) ";
 
       if (user != null) {
         query += "AND rq.client_dn = ?";
@@ -57,9 +57,10 @@ public class SURLStatusDAO {
 
       stat.setString(1, explanation);
       stat.setString(2, surl.getSURLString());
+      stat.setInt(3, surl.uniqueId());
 
       if (user != null) {
-        stat.setString(3, user.getDn());
+        stat.setString(4, user.getDn());
       }
 
       final int updateCount = stat.executeUpdate();
@@ -97,8 +98,8 @@ public class SURLStatusDAO {
         + "JOIN (request_Put rp, request_queue rq) "
         + "ON sp.request_PutID=rp.ID AND rp.request_queueID=rq.ID "
         + "SET sp.statusCode=20, rq.status=20, sp.explanation=? "
-        + "WHERE (sp.statusCode=24 OR sp.statusCode=17) "
-        + "AND rp.targetSURL = ? ";
+        + "WHERE rp.targetSURL = ? and rp.targetSURL_uniqueID = ? "
+        + "AND (sp.statusCode=24 OR sp.statusCode=17)";
 
       if (user != null) {
         query += "AND rq.client_dn = ?";
@@ -107,9 +108,10 @@ public class SURLStatusDAO {
       stat = con.prepareStatement(query);
       stat.setString(1, explanation);
       stat.setString(2, surl.getSURLString());
-
+      stat.setInt(3,  surl.uniqueId());
+      
       if (user != null) {
-        stat.setString(3, user.getDn());
+        stat.setString(4, user.getDn());
       }
 
       final int updateCount = stat.executeUpdate();


### PR DESCRIPTION
The query to update the status of ongoing PtG and PtP requests
should leverage the index on surls unique_id column in order
to save mysql lots of useless work.