### PR TITLE
storm-native-libs version bumped to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>StoRM Backend server</name>
   <groupId>org.italiangrid.storm</groupId>
   <artifactId>storm-backend-server</artifactId>
-  <version>1.11.8</version>
+  <version>1.11.9-SNAPSHOT</version>
 
   <properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <guavaVersion>18.0</guavaVersion>
 
-    <nativeInterfaceVersion>1.0.3</nativeInterfaceVersion>
+    <nativeInterfaceVersion>1.0.4</nativeInterfaceVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
   </properties>


### PR DESCRIPTION
With the upgraded StoRM Native Libs, the LCMAPS logging destination has been turned into only USR_LOG instead of both USR_LOG and SYS_LOG