### PR TITLE
Log srmRm errors as info

### DIFF
--- a/src/main/java/it/grid/storm/synchcall/command/directory/RmCommand.java
+++ b/src/main/java/it/grid/storm/synchcall/command/directory/RmCommand.java
@@ -149,7 +149,7 @@ public class RmCommand implements Command {
       try {
         returnStatus = removeFile(surl, user, data);
       } catch (RmException e) {
-        log.error("srmRm: {}", e.getMessage());
+        log.info("srmRm failed: {}", e.getMessage());
         returnStatus = e.getReturnStatus();
       } finally {
         arrayOfFileStatus.addTSurlReturnStatus(new TSURLReturnStatus(surl,


### PR DESCRIPTION
Since mostly errors are caused by invalid client requests.