### PR TITLE
Include Jetty handler metrics reporting in storm-backend-metrics log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
     <xalanVersion>2.7.1</xalanVersion>
     <mailVersion>1.4.6</mailVersion>
     <jakartaOroVersion>2.0.8</jakartaOroVersion>
+    <jakartaXmlBindVersion>2.3.3</jakartaXmlBindVersion>
+
+    <mysqlConnectorVersion>5.1.12</mysqlConnectorVersion>
 
     <guavaVersion>18.0</guavaVersion>
     <metrics.version>3.1.0</metrics.version>
@@ -502,7 +505,13 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.12</version>
+      <version>${mysqlConnectorVersion}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${jakartaXmlBindVersion}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>StoRM Backend server</name>
   <groupId>org.italiangrid.storm</groupId>
   <artifactId>storm-backend-server</artifactId>
-  <version>1.11.18</version>
+  <version>1.11.19</version>
 
   <properties>
 

--- a/src/main/java/it/grid/storm/metrics/StormMetricsReporter.java
+++ b/src/main/java/it/grid/storm/metrics/StormMetricsReporter.java
@@ -108,6 +108,8 @@ public class StormMetricsReporter extends ScheduledReporter {
     reportThreadPoolMetrics("xmlrpc-tp", gauges);
     reportThreadPoolMetrics("rest-tp", gauges);
 
+    reportJettyHandlerMetrics("xmlrpc-handler", meters);
+    reportJettyHandlerMetrics("rest-handler", meters);
   }
 
   private void reportMetric(String name, Timer timer) {
@@ -134,6 +136,26 @@ public class StormMetricsReporter extends ScheduledReporter {
 
     LOG.info("{} [active-threads={}, idle-threads={}, jobs={}, utilization-max={}, percent-idle={}]",
         tpName, activeThreads, idleThreads, jobs, utilizationMax, percentIdle);
+  }
+
+  private void reportJettyHandlerMetrics(String handlerName, SortedMap<String, Meter> meters) {
+
+    reportMetric(handlerName + ".2xx-responses", meters.get(handlerName + ".2xx-responses"));
+    reportMetric(handlerName + ".3xx-responses", meters.get(handlerName + ".3xx-responses"));
+    reportMetric(handlerName + ".4xx-responses", meters.get(handlerName + ".4xx-responses"));
+    reportMetric(handlerName + ".5xx-responses", meters.get(handlerName + ".5xx-responses"));
+    reportMetric(handlerName + ".requests", meters.get(handlerName + ".requests"));
+    reportMetric(handlerName + ".expires", meters.get(handlerName + ".expires"));
+
+  }
+
+  private void reportMetric(String name, Meter meter) {
+
+    LOG.info(
+        "{} [(count={}, m1_rate={}, m5_rate={}, m15_rate={}, mean_rate={})] rate_units={}",
+        name, meter.getCount(), convertRate(meter.getOneMinuteRate()),
+        convertRate(meter.getFiveMinuteRate()), convertRate(meter.getFifteenMinuteRate()),
+        convertRate(meter.getMeanRate()), getRateUnit());
   }
 
   @Override


### PR DESCRIPTION
Example of new log entries:

```
2020-09-14 17:59:28,651 - xmlrpc-handler.2xx-responses [(count=13, m1_rate=7.164690848707708, m5_rate=2.285879536415916, m15_rate=0.829770158626851, mean_rate=2.6371930676496147)] rate_units=events/minute
2020-09-14 17:59:28,651 - xmlrpc-handler.3xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - xmlrpc-handler.4xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - xmlrpc-handler.5xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - xmlrpc-handler.requests [(count=13, m1_rate=7.164690848707708, m5_rate=2.285879536415916, m15_rate=0.829770158626851, mean_rate=2.6371879092494)] rate_units=events/minute
2020-09-14 17:59:28,651 - xmlrpc-handler.expires [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.2xx-responses [(count=78, m1_rate=24.038882299303445, m5_rate=10.405819797933594, m15_rate=4.484526624848493, mean_rate=15.836196992426599)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.3xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.4xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.5xx-responses [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.requests [(count=78, m1_rate=24.038882299303445, m5_rate=10.405819797933594, m15_rate=4.484526624848493, mean_rate=15.836165786136254)] rate_units=events/minute
2020-09-14 17:59:28,651 - rest-handler.expires [(count=0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0)] rate_units=events/minute 
```