### PR TITLE
Fix for STOR-1395

### DIFF
--- a/etc/systemd/storm-backend-server.service
+++ b/etc/systemd/storm-backend-server.service
@@ -14,6 +14,7 @@ ExecStart=/bin/bash -ac "exec /usr/bin/java \
     -Djna.library.path=/usr/lib64/modules:/usr/lib64/ \
     it.grid.storm.Main > /var/log/storm/storm-backend.stdout 2> /var/log/storm/storm-backend.stderr"
 KillMode=process
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Starting the backend service works fine but when stopping, the service remains in a failed state:

```
Apr 16 16:06:07 omii005-vm03.cnaf.infn.it systemd[1]: storm-backend-server.service: main process exited, code=exited, status=143/n/a
Apr 16 16:06:07 omii005-vm03.cnaf.infn.it systemd[1]: Stopped StoRM Backend service.
Apr 16 16:06:07 omii005-vm03.cnaf.infn.it systemd[1]: Unit storm-backend-server.service entered failed state.
Apr 16 16:06:07 omii005-vm03.cnaf.infn.it systemd[1]: storm-backend-server.service failed.
Apr 16 16:06:07 omii005-vm03.cnaf.infn.it systemd[1]: Started StoRM Backend service.
```

Exit code 143 means that the program received a SIGTERM signal to instruct it to exit. The JVM catches the signal, does a clean shutdown, i.e. it runs all registered shutdown hooks (there's one for StoRM Backend which stops several threads and services), but still exits with an exit code of 143. That's just how Java works.
We suppressed this by adding the exit code into the unit file as a "success" exit status:

```
[Service]
SuccessExitStatus=143
```
```
Apr 16 16:56:52 omii005-vm03.cnaf.infn.it systemd[1]: Stopped StoRM Backend service.
Apr 16 16:56:52 omii005-vm03.cnaf.infn.it systemd[1]: Started StoRM Backend service.
```